### PR TITLE
add new target file for shim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ members = [
     "shim",
 ]
 
+default-members = [
+    "code",
+    "load"
+]
+
 [profile.dev]
 panic = "abort"
 

--- a/shim/build.rs
+++ b/shim/build.rs
@@ -1,4 +1,3 @@
 fn main() {
-    println!("cargo:rustc-link-arg-bin=shim=-Wl,--sort-section=alignment");
-    println!("cargo:rustc-link-arg-bin=shim=-nostartfiles");
+    // println!("cargo:rustc-link-arg-bin=shim=-Wl,-Tlayout.ld");
 }

--- a/x86_64-unknown-none-enarxshimsev.json
+++ b/x86_64-unknown-none-enarxshimsev.json
@@ -1,0 +1,33 @@
+{
+  "arch": "x86_64",
+  "cpu": "x86-64",
+  "crt-static-default": true,
+  "crt-static-respected": true,
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "frame-pointer": "always",
+  "executables": true,
+  "env": "musl",
+  "features": "+rdrnd,+rdseed,+sgx",
+  "has-elf-tls": false,
+  "is-builtin": false,
+  "llvm-target": "x86_64-unknown-linux-musl",
+  "max-atomic-width": 64,
+  "os": "linux",
+  "panic-strategy": "abort",
+  "position-independent-executables": true,
+  "pre-link-args": {
+    "gcc": [
+      "-nostartfiles",
+      "-Wl,--sort-section=alignment"
+    ]
+  },
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "call"
+  },
+  "static-position-independent-executables": true,
+  "target-family": [
+    "unix"
+  ],
+  "target-pointer-width": "64"
+}


### PR DESCRIPTION
Needs a 2-step compile:

```
$ cargo +nightly build
    Finished dev [unoptimized + debuginfo] target(s) in 0.00s

$ cargo +nightly build -Zbuild-std-features=compiler-builtins-mem -Z build-std=core --target x86_64-unknown-none-enarxshimsev.json  -p shim
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
```