### PR TITLE
Simplify build command (still two-step)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
 [unstable]
 extra-link-arg = true
+build-std-features = ["compiler-builtins-mem"]
+
+[build]
+target = "x86_64-unknown-none-enarxshimsev.json"

--- a/load/Cargo.toml
+++ b/load/Cargo.toml
@@ -1,7 +1,10 @@
+cargo-features = ["per-package-target"]
+
 [package]
 name = "load"
 version = "0.1.0"
 edition = "2018"
+forced-target = "x86_64-unknown-linux-gnu"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+targets = [ "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl" ]


### PR DESCRIPTION
```
$ cargo build -Z build-std=core -p shim
   Compiling compiler_builtins v0.1.47
   Compiling core v0.0.0
   Compiling shim v0.1.0
   Compiling rustc-std-workspace-core v1.99.0
    Finished dev [unoptimized + debuginfo] target(s) in 7.17s

$ cargo build
   Compiling load v0.1.0 (/home/npmccallum/enarx/example/load)
   Compiling code v0.1.0 (/home/npmccallum/enarx/example/code)
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s

$ find target/ -maxdepth 3 -perm -u=x -type f
target/x86_64-unknown-none-enarxshimsev/debug/shim
target/x86_64-unknown-linux-gnu/debug/load
target/x86_64-unknown-linux-musl/debug/code
```

Signed-off-by: Nathaniel McCallum <nathaniel@congru.us>